### PR TITLE
Images Webp affichées

### DIFF
--- a/webPages/Admin.php
+++ b/webPages/Admin.php
@@ -85,7 +85,7 @@ include 'MODULES/end.php';
         <?php while($m = $membres->fetch()) { ?>
             <a href="Profil.php?id=<?= $m['id'] ?>" class="noUnderline" title="<?= $m['pseudo']?>    ID : <?= $m['id'] ?>">
                 <div class="cardArticle">
-                    <img style="width:300%" class="" src="membres/avatars/<?php echo $m['avatar']; ?>" loading="lazy" />
+                    <img style="width:300%" class="" src="membres/avatars/<?php echo $m['avatar'].'.webp'; ?>" loading="lazy" />
                 </div>    
             </a>
             <!-- Pour toi flo ;)

--- a/webPages/Article.php
+++ b/webPages/Article.php
@@ -57,7 +57,7 @@ include 'MODULES/end.php';
                 <a href="Publication.php?id=<?= $a['id'] ?>" class="noUnderline" title="<?= $a['descriptions'] ?>">
                     <div class="cardArticle">
                         <?php if(!empty($a['avatar_article'])) { ?>
-                            <img class="cardArticleImage" src="membres/avatars_article/<?= $a['avatar_article'] ?>" />
+                            <img class="cardArticleImage" src="membres/avatars_article/<?= $a['avatar_article'].'.webp' ?>" />
                         <?php } ?>
                         <p class="title"><?= $a['titre'] ?></p>
                         <p class="date"><?= date('m/d', strtotime($a['date_time_publication'])) ?></p>

--- a/webPages/MODULES/profil.php
+++ b/webPages/MODULES/profil.php
@@ -9,7 +9,7 @@ if(isset($_SESSION['id']) && ($_SESSION['id'] > 0)) {
 ?>
 <div class="module">
     <?php if(!empty($M_userinfos['avatar'])) { ?>
-        <img src="membres/avatars/<?php echo $M_userinfos['avatar']; ?>" class="avatar hcenter" style="max-width:7em;">
+        <img src="membres/avatars/<?php echo $M_userinfos['avatar'].'.webp'; ?>" class="avatar hcenter" style="max-width:7em;">
     <?php } ?>
     <b><a href="Profil.php?id=<?= $M_userinfos['id'] ?>"><?php echo $M_userinfos['pseudo']; ?></a></b>
     <a href="deconnexion.php"><div class="PActions">Se déconnecter</div></a>

--- a/webPages/Profil.php
+++ b/webPages/Profil.php
@@ -35,7 +35,7 @@ if(isset($_GET['id']) AND $_GET['id'] > 0) {
         </div>
 
         <?php if(!empty($userinfos['avatar'])) { ?>
-            <img src="membres/avatars/<?php echo $userinfos['avatar']; ?>" class="avatar" width="150" style="margin:5px;">
+            <img src="membres/avatars/<?php echo $userinfos['avatar'].'.webp'; ?>" class="avatar" width="150" style="margin:5px;">
         <?php } ?>
                 <br /><b>Pseudonyme:</b><br />
                 <div class="PCapsule">

--- a/webPages/Publication.php
+++ b/webPages/Publication.php
@@ -135,7 +135,7 @@ include 'MODULES/end.php';
                         <a href="Publication.php?id=<?= $a['id'] ?>" class="noUnderline" title="<?= $a["date_time_publication"] ?>">
                             <div class="cardArticle">
                                 <?php if(!empty($a['avatar_article'])) { ?>
-                                    <img class="cardArticleImage" src="membres/avatars_article/<?= $a['avatar_article'] ?>" />
+                                    <img class="cardArticleImage" src="membres/avatars_article/<?= $a['avatar_article'].'.webp' ?>" />
                                 <?php } ?>
                                 <p class="title"><?= $a['titre'] ?></p>
                                 <p class="desc"><?= $a['descriptions'] ?></p>
@@ -179,7 +179,7 @@ include 'MODULES/end.php';
                     $avatarInfos = $pseudoAvatar->fetch(); ?>
                 <div class="CBlock">
                     <?php if(!empty($avatarInfos)) { ?>
-                        <a class="noUnderline" href="Profil.php?id=<?= $avatarInfos['id'] ?>"><img src="membres/avatars/<?php echo $avatarInfos['avatar']; ?>" width="50"></a>
+                        <a class="noUnderline" href="Profil.php?id=<?= $avatarInfos['id'] ?>"><img src="membres/avatars/<?php echo $avatarInfos['avatar'].'.webp'; ?>" width="50"></a>
                     <?php } ?>
                     
                     <a href="Profil.php?id=<?= $avatarInfos['id'] ?>"><div class=NCapsule><b><?= $c['pseudo'] ?><br /></b></div></a>

--- a/webPages/actualisation_publication.php
+++ b/webPages/actualisation_publication.php
@@ -27,7 +27,7 @@ $search_auteur = $bdd->prepare('SELECT * FROM `membres` WHERE id = ?');
         <a href="Publication.php?id=<?= $a['id'] ?>" class="noUnderline" title="<?= $a['descriptions'] ?>">
             <div class="cardArticle">
                 <?php if(!empty($a['avatar_article'])) { ?>
-                    <img class="cardArticleImage" src="membres/avatars_article/<?= $a['avatar_article'] ?>" />
+                    <img class="cardArticleImage" src="membres/avatars_article/<?= $a['avatar_article'].'.webp' ?>" />
                 <?php } ?>
                 <p class="title"><?= $a['titre'] ?></p>
                 <p class="date"><?= date('m/d', strtotime($a['date_time_publication'])) ?></p>

--- a/webPages/main.php
+++ b/webPages/main.php
@@ -73,7 +73,7 @@ include 'MODULES/end.php';
                 ?>
                 <a href="Publication.php?id=<?= $a_r['id'] ?>" class="noUnderline">
                 <?php if(!empty($a_r['avatar_article'])) { ?>
-                    <img class="cardArticleImage" src="membres/avatars_article/<?php echo $a_r['avatar_article']; ?>" href="Publication.php?id=<?= $a_r['id'] ?>" style="width:100%;" loading="lazy"/>
+                    <img class="cardArticleImage" src="membres/avatars_article/<?php echo $a_r['avatar_article'].'.webp'; ?>" href="Publication.php?id=<?= $a_r['id'] ?>" style="width:100%;" loading="lazy"/>
                 <?php } ?>
                     <div class="cardArticle" style='<?php if(!empty($a_r['avatar_article'])) { ?>
                     background: center url("membres/avatars_article/<?= $a_r['avatar_article'] ?>");


### PR DESCRIPTION
Fait rapidement, on utilise les images webp (on peut supprimer les autres, puisqu'elles ne seront jamais chargées, sauf en cas de changement de code)
- Charger l'image en format WEBP, mais ne pas considérer d'alternative en cas de problème ou de non-compatibilité